### PR TITLE
Performance improvement for scikit-learn training

### DIFF
--- a/prediction_models/code/01_elastic_net_sklearn_model.py
+++ b/prediction_models/code/01_elastic_net_sklearn_model.py
@@ -2,6 +2,7 @@ from sklearn.linear_model import ElasticNetCV
 import pandas as pd
 import numpy as np
 from xopen import xopen # Used to transparently open compressed files
+from threadpoolctl import threadpool_limits # Better performance by limiting to 1 BLAS thread
 
 import os
 import time
@@ -277,7 +278,8 @@ for lip in lst_lipids:
                             n_jobs=args.n_jobs,
                             l1_ratio=0.5) # Default l1 ratio=0.5
         X = dosage_all.T
-        regr.fit(X, y)
+        with threadpool_limits(limits=1, user_api='blas'):
+            regr.fit(X, y)
 
         end_time = time.time()
         print(f'# - Model fitting finised in {(end_time - start_time):.4f}s')


### PR DESCRIPTION
These changes help make training faster, and will enable us to train a lot of models quickly.

1. Introduce `xopen` to work with compressed files for all input. 
2. Filter dosage lines using regex to avoid unnecessary splitting of large lines of text.
3. Limit BLAS concurrency using threadpoolctl. My own testing discovered that default settings result in huge wasted CPU time.
4. Make n_jobs a configurable option. We probably want to stay around 2